### PR TITLE
Respond with empty arrays from profiles_get and match_show actions instead of a 404

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -15,25 +15,15 @@ class Api::V1::ProfilesController < ApplicationController
     @profile = Profile.find(params[:profile_id])
     exclude_profiles = [@profile.id.to_s] + @profile.accepted_profiles + @profile.rejected_profiles
     profile_select = Profile.where.not(id: exclude_profiles).order('random()').first(5)
-    if profile_select != []
-      render json: profile_select
-    else
-      render json: {
-          error: "No new profiles, come back later!"
-      }, status: 404
-    end
+
+    render json: profile_select
   end
 
   def match_show
     @profile = Profile.find(params[:profile_id])
     matches = MatchPair.where(profile_id: @profile.id).or(MatchPair.where(match_id: @profile.id))
-    if matches != []
-      render json: matches
-    else
-      render json: {
-          error: "No matches, come back later!"
-      }, status: 404
-    end
+
+    render json: matches
   end
 
   def accept


### PR DESCRIPTION
This makes the responses easier to handle on the front end as we can check for the array length, instead of having to add in 404 error handling.

These changes are depended upon by the frontend `matches` branch: https://github.com/ben-zeng/wagster_frontend/commits/matches